### PR TITLE
README.md add link to translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,16 @@
 - Load and persist songs from anywhere using Android's S.A.F!
 - Part of the CuteApps ecosystem!
 - Makes you a cutie!
-   
+
+---
+<h1>🌐 Translation</h1>
+
+Please help with translations on the [Weblate](https://toolate.othing.xyz/projects/cutemusic).
+
+<a href="https://toolate.othing.xyz/projects/cutemusic">
+<img src="https://toolate.othing.xyz/widget/cutemusic/metadata/multi-auto.svg" alt="Translation status" />
+</a>
+
 ---
 <h1>💬 Contact Me</h1>
 


### PR DESCRIPTION
Closes: #173

To make it easier to translate it would be great to integrate a translation service.
The https://toolate.othing.xyz/ is an instance of the [Weblate](https://weblate.org/), it has no pre-moderation, it can send a PR with translations, it has automatic translations from Baidu to help to translators. It's used by many of the F-Droid apps.

I created a translation project on the Toolate https://toolate.othing.xyz/projects/cutemusic
and also made a testing translations and it sent you a PR #182.

If you are fine with the solution then please merge the PR that adds the Toolate link to the README to help users to find it. Also if you wish I can send you an invitation to become an admin of the translation project (needed sometimes to resolve merge conflicts).

Thank you for the app!