### PR TITLE
fix(Settings): navigate up when no backstack is empty

### DIFF
--- a/app/src/main/java/com/sosauce/cutemusic/presentation/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/sosauce/cutemusic/presentation/screens/settings/SettingsScreen.kt
@@ -80,7 +80,13 @@ fun SettingsScreen(
 
     NavDisplay(
         backStack = backStack,
-        onBack = { backStack.removeLastOrNull() },
+        onBack = { 
+            if (backStack.size > 1) {
+                backStack.removeLastOrNull()
+            } else {
+                onNavigateUp()
+            }
+        },
         predictivePopTransitionSpec = {
             ContentTransform(
                 fadeIn(),


### PR DESCRIPTION
Fixes #189 

Error:
```
ComposeInternal com.sosauce.cutemusic.debug E Error was captured in composition.
    java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty
```