### PR TITLE
10-band EQ support

### DIFF
--- a/app/src/main/java/com/sosauce/chocola/domain/PlaybackService.kt
+++ b/app/src/main/java/com/sosauce/chocola/domain/PlaybackService.kt
@@ -159,17 +159,23 @@ class PlaybackService : MediaLibraryService(), MediaLibrarySession.Callback, Pla
     }
 
     private suspend fun setupEqualizerBands(equalizer: Equalizer) {
-        val tempEqBands = mutableListOf<EqualizerBand>()
+        val targetFrequencies = intArrayOf(
+            31_000,
+            63_000,
+            125_000,
+            250_000,
+            500_000,
+            1_000_000,
+            2_000_000,
+            4_000_000,
+            8_000_000,
+            16_000_000
+        )
 
-
-        (0 until equalizer.numberOfBands).forEach { index ->
-            val band = index.toShort()
-            val centerFreq = equalizer.getCenterFreq(band) // millihertz
-            val decibel = equalizer.getBandLevel(band) // millibels
-
-            tempEqBands.add(
-                EqualizerBand(centerFreq, decibel)
-            )
+        val tempEqBands = targetFrequencies.map { centerFreq ->
+            val band = equalizer.getBand(centerFreq)
+            val decibel = if (band >= 0) equalizer.getBandLevel(band) else 0.toShort()
+            EqualizerBand(centerFreq, decibel)
         }
 
         userPreferences.saveEqualizerBands(tempEqBands)

--- a/app/src/main/java/com/sosauce/chocola/presentation/screens/settings/SettingsPlayback.kt
+++ b/app/src/main/java/com/sosauce/chocola/presentation/screens/settings/SettingsPlayback.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -189,6 +190,7 @@ fun SettingsPlayback(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
+                                .horizontalScroll(rememberScrollState())
                                 .padding(10.dp),
                             horizontalArrangement = Arrangement.SpaceBetween
                         ) {


### PR DESCRIPTION
Changes the EQ to use 10 (or 5 on unsupported hardware) hardcoded bands instead of the system-provided ones.

System presets are still present, but are remapped when applied.

Existing preset handling tbd 

Also fixes a the band frequency labels showing kHz instead of Hz.  

Closes #318 